### PR TITLE
Add support for comma as decimal delimiter

### DIFF
--- a/ethers/src/Payment.h
+++ b/ethers/src/Payment.h
@@ -50,4 +50,13 @@ typedef NS_OPTIONS(NSUInteger, EtherFormatOption) {
 
 + (BigNumber*)parseEther: (NSString*)etherString;
 
+/**
+ Figure out the decimal separator that is used in a string. If no separator
+ is found "." is returned.
+ 
+ @param string The string for which we want to get the decimal separator
+ @returns Either "," or "."
+ */
++ (NSString* )decimalSeparatorForString:(NSString *)string;
+
 @end

--- a/ethers/src/Payment.m
+++ b/ethers/src/Payment.m
@@ -122,6 +122,8 @@ static RegEx *RegexNumbersOnly = nil;
     NSString *whole = [weiString substringToIndex:decimalIndex];
     NSString *decimal = [weiString substringFromIndex:decimalIndex];
     
+    NSString *separator = [[NSLocale currentLocale] decimalSeparator];
+    
     if (options & EtherFormatOptionCommify) {
         NSString *commified = @"";
         //NSMutableArray *parts = [NSMutableArray arrayWithCapacity:(whole.length + 2) / 3];
@@ -129,7 +131,7 @@ static RegEx *RegexNumbersOnly = nil;
             //NSLog(@"FOO: %@", whole);
             NSInteger chunkStart = whole.length - 3;
             if (chunkStart < 0) { chunkStart = 0; }
-            commified = [NSString stringWithFormat:@"%@,%@", [whole substringFromIndex:chunkStart], commified];
+            commified = [NSString stringWithFormat:@"%@%@%@", [whole substringFromIndex:chunkStart], separator, commified];
             whole = [whole substringToIndex:chunkStart];
         }
         
@@ -152,8 +154,19 @@ static RegEx *RegexNumbersOnly = nil;
     return [NSString stringWithFormat:@"%@.%@", whole, decimal];
 }
 
++ (NSString* )decimalSeparatorForString:(NSString *)string {
+    if ([string rangeOfString:@"."].location != NSNotFound) {
+        return @".";
+    } else if ([string rangeOfString:@","].location != NSNotFound) {
+        return @",";
+    }
+    return @".";
+}
+
 + (BigNumber*)parseEther: (NSString*)etherString {
-    if ([etherString isEqualToString:@"."]) { return nil; }
+    NSString *separator = [self decimalSeparatorForString:etherString];
+    
+    if ([etherString isEqualToString:separator]) { return nil; }
     
     BOOL negative = NO;
     if ([etherString hasPrefix:@"-"]) {
@@ -163,7 +176,7 @@ static RegEx *RegexNumbersOnly = nil;
     
     if (etherString.length == 0) { return nil; }
     
-    NSArray *parts = [etherString componentsSeparatedByString:@"."];
+    NSArray *parts = [etherString componentsSeparatedByString:separator];
     if ([parts count] > 2) { return nil; }
     
     NSString *whole = [parts objectAtIndex:0];

--- a/ethersTests/test-ether-format.m
+++ b/ethersTests/test-ether-format.m
@@ -53,20 +53,36 @@
                        @{@"test": @"1.00", @"result": @"1000000000000000000"},
                        @{@"test": @"01.0", @"result": @"1000000000000000000"},
 
+                       @{@"test": @"123,012345678901234567", @"result": @"123012345678901234567"},
+                       @{@"test": @"1,0", @"result": @"1000000000000000000"},
+                       @{@"test": @"1,00", @"result": @"1000000000000000000"},
+                       @{@"test": @"01,0", @"result": @"1000000000000000000"},
+
                        @{@"test": @"0", @"result": @"0"},
                        @{@"test": @"-0", @"result": @"0"},
                        @{@"test": @"00", @"result": @"0"},
                        @{@"test": @"0.0", @"result": @"0"},
                        @{@"test": @".00", @"result": @"0"},
                        @{@"test": @"00.00", @"result": @"0"},
+                       
+                       @{@"test": @"0,0", @"result": @"0"},
+                       @{@"test": @",00", @"result": @"0"},
+                       @{@"test": @"00,00", @"result": @"0"},
 
                        @{@"test": @"-1.0", @"result": @"-1000000000000000000"},
+                       @{@"test": @"-1,0", @"result": @"-1000000000000000000"},
                        
                        @{@"test": @"0.1", @"result": @"100000000000000000"},
                        @{@"test": @".1", @"result": @"100000000000000000"},
                        @{@"test": @"0.10", @"result": @"100000000000000000"},
                        @{@"test": @".100", @"result": @"100000000000000000"},
                        @{@"test": @"00.100", @"result": @"100000000000000000"},
+                       
+                       @{@"test": @"0,1", @"result": @"100000000000000000"},
+                       @{@"test": @",1", @"result": @"100000000000000000"},
+                       @{@"test": @"0,10", @"result": @"100000000000000000"},
+                       @{@"test": @",100", @"result": @"100000000000000000"},
+                       @{@"test": @"00,100", @"result": @"100000000000000000"},
                        
                        @{@"test": @"-0.1", @"result": @"-100000000000000000"},
                        ];
@@ -124,14 +140,21 @@
     NSArray *tests = @[
                        @"",
                        @".",
+                       @",",
                        @"-",
                        @"0.0.0",
+                       @"0,0,0",
                        @"a",
                        @"0.1\nfoobar",
+                       @"0,1\nfoobar",
                        @"0.a",
+                       @"0,a",
                        @"a.0",
+                       @"a,0",
                        @"123.a",
+                       @"123,a",
                        @"a.1234",
+                       @"a,1234",
                        @"0x56",
                        @"1.0123456789012345678",  // Too many decimals
                        @"-1.0123456789012345678", // Too many decimals (negative)
@@ -236,6 +259,11 @@
                            @"amount": @"1.234",
                            @"address": @"0x06B5955A67D827CDF91823E3bB8F069e6c89c1D6"
                            },
+                       @{
+                           @"uri": @"IBAN://XE68S7PCGWBX6SF95M9C1KVXUWCWTPLPLI?amount=1,234",
+                           @"amount": @"1,234",
+                           @"address": @"0x06B5955A67D827CDF91823E3bB8F069e6c89c1D6"
+                           },
                       ];
     
     for (NSDictionary *testcase in tests) {
@@ -277,6 +305,24 @@
         XCTAssertNil(result, @"Failed to fail on parseURI: %@", testcase);
         _assertionCount++;
     }
+}
+
+- (void)testDecimalSeparatorIsCorrectlyDetectedForDots {
+    NSString *separator = [Payment decimalSeparatorForString:@"2.3"];
+    
+    XCTAssertEqual(separator, @".");
+}
+
+- (void)testDecimalSeparatorIsCorrectlyDetectedForCommas {
+    NSString *separator = [Payment decimalSeparatorForString:@"2,3"];
+    
+    XCTAssertEqual(separator, @",");
+}
+
+- (void)testDecimalSeparatorIsCorrectlyDetectedForAnythingElse {
+    NSString *separator = [Payment decimalSeparatorForString:@"1234:45"];
+    
+    XCTAssertEqual(separator, @".");
 }
 
 @end


### PR DESCRIPTION
This adds support for "," as decimal delimiter.

The implementation is rather quirky based on the current structure of the string formatting. I added new unit tests, everything should be backwards compatible.

Part 1 to solve https://github.com/ethers-io/EthersWallet-ios/issues/8