### PR TITLE
Fix -[Account isEqual:]

### DIFF
--- a/ethers/src/Account.m
+++ b/ethers/src/Account.m
@@ -628,7 +628,7 @@ static NSDateFormatter *TimeFormatter = nil;
 #pragma mark - NSObject
 
 - (BOOL)isEqual:(id)object {
-    if ([object isKindOfClass:[Account class]]) { return NO; }
+    if (![object isKindOfClass:[Account class]]) { return NO; }
     return [[self _privateKeyHash] isEqualToString:[((Account*)object) _privateKeyHash]];
 }
 


### PR DESCRIPTION
`-isEqual` contained a logic error, making comparisons to other `Accounts` always fail.

I checked other classes as well, but it seems this was the only instance of this typo.